### PR TITLE
Fix retry reconnect 

### DIFF
--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -105,8 +105,10 @@ impl HttpError {
             if let Some(e) = e.downcast_ref::<hyper::Error>() {
                 if e.is_closed() || e.is_incomplete_message() || e.is_body_write_aborted() {
                     kind = HttpErrorKind::Request;
+                    break;
                 } else if e.is_timeout() {
                     kind = HttpErrorKind::Timeout;
+                    break;
                 }
             }
             if let Some(e) = e.downcast_ref::<std::io::Error>() {
@@ -118,6 +120,7 @@ impl HttpError {
                     | std::io::ErrorKind::UnexpectedEof => kind = HttpErrorKind::Interrupted,
                     _ => {}
                 }
+                break;
             }
             source = e.source();
         }

--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -102,16 +102,12 @@ impl HttpError {
         // Reqwest error variants aren't great, attempt to refine them
         let mut source = e.source();
         while let Some(e) = source {
-            let mut is_hyper_error = false;
-            let mut is_io_error = false;
-
             if let Some(e) = e.downcast_ref::<hyper::Error>() {
                 if e.is_closed() || e.is_incomplete_message() || e.is_body_write_aborted() {
                     kind = HttpErrorKind::Request;
                 } else if e.is_timeout() {
                     kind = HttpErrorKind::Timeout;
                 }
-                is_hyper_error = true;
             }
             if let Some(e) = e.downcast_ref::<std::io::Error>() {
                 match e.kind() {
@@ -122,10 +118,6 @@ impl HttpError {
                     | std::io::ErrorKind::UnexpectedEof => kind = HttpErrorKind::Interrupted,
                     _ => {}
                 }
-                is_io_error = true;
-            }
-            if is_hyper_error || is_io_error {
-                break;
             }
             source = e.source();
         }

--- a/src/client/http/connection.rs
+++ b/src/client/http/connection.rs
@@ -102,13 +102,16 @@ impl HttpError {
         // Reqwest error variants aren't great, attempt to refine them
         let mut source = e.source();
         while let Some(e) = source {
+            let mut is_hyper_error = false;
+            let mut is_io_error = false;
+
             if let Some(e) = e.downcast_ref::<hyper::Error>() {
                 if e.is_closed() || e.is_incomplete_message() || e.is_body_write_aborted() {
                     kind = HttpErrorKind::Request;
                 } else if e.is_timeout() {
                     kind = HttpErrorKind::Timeout;
                 }
-                break;
+                is_hyper_error = true;
             }
             if let Some(e) = e.downcast_ref::<std::io::Error>() {
                 match e.kind() {
@@ -119,6 +122,9 @@ impl HttpError {
                     | std::io::ErrorKind::UnexpectedEof => kind = HttpErrorKind::Interrupted,
                     _ => {}
                 }
+                is_io_error = true;
+            }
+            if is_hyper_error || is_io_error {
                 break;
             }
             source = e.source();


### PR DESCRIPTION
`rtdb` snapshotter has suffered from bug of no-retry-on-reconnect for long:

`Service(ObjectStore(Generic { store: "S3", source: RetryError { method: PUT, uri: Some(XXX-REDACTED-XXX), retries: 0, max_retries: 3, elapsed: 801.473µs, retry_timeout: 60s, inner: Http(HttpError { kind: Unknown, source: reqwest::Error { kind: Request, source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(Io, Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" })) } }) } })`

The “unknown” indicates hyper is failing to classify more precisely so it’s getting swallowed and the proposed fix https://github.com/apache/arrow-rs-object-store/pull/351 doesn't completely fix it because of these early breaks, which, when successfully resolving hyper::Error, it just simple breaks out the loop without even attempting to dive into io error. The rest of recursion is totally skipped, thus defeating the recursive purpose of fix https://github.com/apache/arrow-rs-object-store/pull/351.

This PR removes these `early breaks` and practices the recursive parsing of the error and thus the io:error would be parsed correctly to be retried.

Tested to work: before and after deploy
https://ddstaging.datadoghq.com/s/c894ecec5/ig8-5nn-gdb
<img width="1439" alt="Screenshot 2025-05-22 at 2 35 38 PM" src="https://github.com/user-attachments/assets/1de89593-c292-4fc2-89eb-d86ae96c3732" />
